### PR TITLE
WIP: Further examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# counterfish
+# Counterfish
 2 register Minsky machine toy programming language.
+
+
+| Token | Description |
+|:-----:|-------------|
+| `i`   | Increment current register |
+| `d`   | If current register is not 0, decrement and skip the next token, otherwise NOP |
+| `s`   | Swap registers |
+| `o`   | Output current register (as an integer, or optionally as a list of integers or characters Gödel encoded using prime factorisation) |
+| `:{label}` | Program label — NOP |
+| `_{label}` | Jump to matching `:{label}` |
+
+### Macros
+
+    repeat(constant) { code block }

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@
 ### Macros
 
     repeat(constant) { code block }
+
+`%CONST%` — User supplied constant `CONST`

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,10 +54,9 @@ R1: 3371625
 
 ### setvc(p, c): [setvc.cfm](setvc.cfm)
 
+    ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/7/g;s/%C%/5/g' examples/setvc.cfm)) -i1
 Sets v.reg.7 to 5 from an empty virtual state (one register still needs to be set to 1 (`-i 1`) to provide something to multiply).
 The code should possibly ensure this is the case?
-
-    ./counterfish.py <(./cfmacro.py <(sed 's/%C%/5/g;s/%VREG%/7/g' examples/setvc.cfm)) -i1
 
 result:
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,70 @@
+# Examples
+
+## Usage
+
+### decv(p): [decv.cfm](decv.cfm)
+
+The output below show `R0` with the initial state (register value, and its prime decoding), `R1` is the final state after applying the code example.
+
+    ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/5/g' examples/decv.cfm)) -i91125
+result:
+```
+R0: 91125
+   [0, 6, 3]
+R1: 18225
+   [0, 6, 2]
+```
+Which shows v.reg 5 (i.e. the third prime number register) decrease from 3 to 2, leaving v.reg.3 unchanged at 6.
+
+
+### incv(p): [incv.cfm](incv.cfm)
+
+Running the increase example on the same state:
+
+    ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/5/g' examples/incv.cfm)) -i91125
+result:
+```
+R0: 91125
+   [0, 6, 3]
+R1: 455625
+   [0, 6, 4]
+```
+
+Running increase on v.reg.3:
+
+    ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/3/g' examples/incv.cfm)) -i91125
+result:
+```
+R0: 91125
+   [0, 6, 3]
+R1: 273375
+   [0, 7, 3]
+```
+
+Running increase on v.reg.37:
+
+     ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/37/g' examples/incv.cfm)) -i91125
+result:
+```
+R0: 91125
+   [0, 6, 3]
+R1: 3371625
+   [0, 6, 3, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+```
+
+### setvc(p, c): [setvc.cfm](setvc.cfm)
+
+Sets v.reg.7 to 5 from an empty virtual state (one register still needs to be set to 1 (`-i 1`) to provide something to multiply).
+The code should possibly ensure this is the case?
+
+    ./counterfish.py <(./cfmacro.py <(sed 's/%C%/5/g;s/%VREG%/7/g' examples/setvc.cfm)) -i1
+
+result:
+```
+R0: 1
+   []
+R0: 0
+   []
+R1: 16807
+   [0, 0, 0, 5]
+```

--- a/examples/decv.cfm
+++ b/examples/decv.cfm
@@ -1,0 +1,16 @@
+:Decrease_virtual_register_%VREG%
+
+o
+
+:decv
+  repeat(%VREG%) { d_zfalse ss }
+  sis
+  d_ztrue i
+_decv
+
+
+:ztrue
+
+
+:zfalse
+so

--- a/examples/incv.cfm
+++ b/examples/incv.cfm
@@ -1,0 +1,13 @@
+:Increase_virtual_register_%VREG%
+
+ddi
+
+o
+
+:incv
+  d_done
+  s repeat(%VREG%) { i } s
+_incv
+
+:done
+so

--- a/examples/multvc.cfm
+++ b/examples/multvc.cfm
@@ -1,0 +1,14 @@
+:Multiply_v.reg_%VREG%_by_a_constant_%C%
+
+o
+
+:Load_constant_into_spare_v.reg.3
+
+s
+
+repeat(%C%) { :incv0 s :incvv0 d_incv1 s repeat(3) { i } s _incvv0 }
+
+:incv%C%
+
+oso
+

--- a/examples/setvc.cfm
+++ b/examples/setvc.cfm
@@ -1,0 +1,21 @@
+:setvc(p,c)
+:Load_a_constant_%C%_into_%VREG%
+
+:Ouput_initial_state
+o
+
+:Load_constant_into_spare_v.reg.%VREG%
+
+s  :Swaps_focused_physical_register
+:this_happens_every_inc_pass_below
+:in_a_Counter_machine_language_without_a_relative_swap_command
+:this_swap_would_have_to_be_performed_manually_using_an
+:increment_decrement_loop.
+
+repeat(%C%) { :incv0 s :incvv0 d_incv1 s repeat(%VREG%) { i } s _incvv0 }
+
+:incv%C%
+
+:Output_final_state_of_both_registers
+oso
+


### PR DESCRIPTION
**TODO**
- [ ] Improve notation / macro expansion to make the examples functional for any prime encoded virtual register  
     (currently `%VREG%` is to be replaced using `sed`)
* The decrease doesn't currently test or leave the data unmodified if it is already zero (currently other registers get messed up if an already zeroed register is decreased below zero)

**Example usage:**

The output below show `R0` with the initial state (register value, and its prime decoding), `R1` is the final state after applying the code example.

    ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/5/g' examples/decv.cfm)) -i91125
result:
```
R0: 91125
   [0, 6, 3]
R1: 18225
   [0, 6, 2]
```
Which shows v.reg 5 (i.e. the third prime number register) decrease from 3 to 2, leaving v.reg.3 unchanged at 6.

Running the increase example on the same state:

    ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/5/g' examples/incv.cfm)) -i91125
result:
```
R0: 91125
   [0, 6, 3]
R1: 455625
   [0, 6, 4]
```

Running increase on v.reg.3:

    ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/3/g' examples/incv.cfm)) -i91125
result:
```
R0: 91125
   [0, 6, 3]
R1: 273375
   [0, 7, 3]
```

Running increase on v.reg.37:

     ./counterfish.py <(./cfmacro.py <(sed 's/%VREG%/37/g' examples/incv.cfm)) -i91125
result:
```
R0: 91125
   [0, 6, 3]
R1: 3371625
   [0, 6, 3, 0, 0, 0, 0, 0, 0, 0, 0, 1]
```

